### PR TITLE
[Feature] CtRawData  nextByte function

### DIFF
--- a/include/core/CtTypes.hpp
+++ b/include/core/CtTypes.hpp
@@ -134,10 +134,20 @@ public:
      * @brief Sets the next byte of the buffer. It also raises the size of the buffer.
      *      If the buffer is full an exception will be thrown - CtOutOfRangeError()
      * 
-     * @param byte The byte to be added.
+     * @param p_data The byte to be added.
      * @return void 
      */
-    EXPORTED_API void nextByte(char byte);
+    EXPORTED_API void setNextByte(CtUInt8 p_data);
+
+    /**
+     * @brief Sets the next byte of the buffer. It also raises the size of the buffer.
+     *      If the buffer is full an exception will be thrown - CtOutOfRangeError()
+     * 
+     * @param p_data The byte to be added.
+     * @param p_size The number of bytes to be added.
+     * @return void 
+     */
+    EXPORTED_API void setNextBytes(CtUInt8* p_data, CtUInt32 p_size);
 
     /**
      * @brief This method returns a pointer to the last N bytes of the buffer.

--- a/src/core/CtTypes.cpp
+++ b/src/core/CtTypes.cpp
@@ -50,10 +50,19 @@ CtRawData::~CtRawData() {
     delete[] m_data;
 }
 
-void CtRawData::nextByte(char byte) {
-    if (m_size < m_maxSize) {
-        m_data[m_size++] = byte;
+void CtRawData::setNextByte(CtUInt8 p_data) {
+    if (m_size >= m_maxSize) {
+        throw CtOutOfRangeError("Data size is out of range.");
+    } 
+    m_data[m_size++] = p_data;
+}
+
+void CtRawData::setNextBytes(CtUInt8* p_data, CtUInt32 p_size) {
+    if (m_size + p_size > m_maxSize) {
+        throw CtOutOfRangeError("Data size is out of range.");
     }
+    memcpy(&m_data[m_size], p_data, p_size);
+    m_size += p_size;
 }
 
 CtUInt8* CtRawData::getNLastBytes(CtUInt32 p_num) {

--- a/src/io/CtFileInput.cpp
+++ b/src/io/CtFileInput.cpp
@@ -65,7 +65,7 @@ bool CtFileInput::read(CtRawData* p_data) {
         CtUInt8* delim_ptr = nullptr;
 
         while (m_file.get(next_char)) {
-            p_data->nextByte(next_char);
+            p_data->setNextByte(next_char);
             
             if (m_delim != nullptr && p_data->size() >= m_delim_size) {
                 delim_ptr = p_data->getNLastBytes(m_delim_size);


### PR DESCRIPTION
- Rename to setNextByte
- Implement setNextBytes that sets the next bytes using a buffer instead of just a byte
- throw CtOutOfRangeError when needed